### PR TITLE
[Front] Refactoring & Add Modal, transition

### DIFF
--- a/front/src/components/Footer.vue
+++ b/front/src/components/Footer.vue
@@ -1,32 +1,13 @@
 <template>
   <div class="clearAllContainer">
-    <span class='clearAllBtn' v-on:click="clearWord">Clear All</span>
+    Footer
   </div>
 </template>
 
 <script>
-export default {
-  methods: {
-    clearWord: function() {
-      localStorage.clear()
-    }
-  }
-}
+
 </script>
 
 <style scoped>
-.clearAllContainer {
-  width: 8.5rem;
-  height: 50px;
-  line-height: 50px;
-  background-color: white;
-  border-radius: 5px;
-  margin: 0 auto;
-}
 
-.clearAllBtn {
-  color: #6138D4;
-  font-style: bold;
-  display: block;
-}
 </style>

--- a/front/src/components/Footer.vue
+++ b/front/src/components/Footer.vue
@@ -1,15 +1,32 @@
 <template>
-  <div>
-    footer
+  <div class="clearAllContainer">
+    <span class='clearAllBtn' v-on:click="clearWord">Clear All</span>
   </div>
 </template>
 
 <script>
 export default {
-
+  methods: {
+    clearWord: function() {
+      localStorage.clear()
+    }
+  }
 }
 </script>
 
-<style>
+<style scoped>
+.clearAllContainer {
+  width: 8.5rem;
+  height: 50px;
+  line-height: 50px;
+  background-color: white;
+  border-radius: 5px;
+  margin: 0 auto;
+}
 
+.clearAllBtn {
+  color: #6138D4;
+  font-style: bold;
+  display: block;
+}
 </style>

--- a/front/src/components/common/Modal.vue
+++ b/front/src/components/common/Modal.vue
@@ -1,0 +1,97 @@
+<template>
+  <transition name="modal">
+	<div class="modal-mask">
+	  <div class="modal-wrapper">
+		<div class="modal-container">
+
+			<div class="modal-header">
+			<slot name="header">
+				default header
+			</slot>
+			</div>
+
+			<div class="modal-body">
+			<slot name="body">
+				default body
+			</slot>
+			</div>
+		</div>
+      </div>
+	</div>
+  </transition>
+</template>
+
+<script>
+export default {
+
+}
+</script>
+
+<style>
+.modal-mask {
+  position: fixed;
+  z-index: 9998;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: table;
+  transition: opacity 0.3s ease;
+}
+
+.modal-wrapper {
+  display: table-cell;
+  vertical-align: middle;
+}
+
+.modal-container {
+  width: 300px;
+  margin: 0px auto;
+  padding: 20px 30px;
+  background-color: rgba(255, 255, 255, 0.767);
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.33);
+  transition: all 0.3s ease;
+  font-family: Helvetica, Arial, sans-serif;
+  color: black;
+  font-weight: bold;
+}
+
+.modal-header h3 {
+  margin-top: 0;
+  color: #6138D4;
+}
+
+.modal-body {
+  margin: 20px 0;
+}
+
+.modal-default-button {
+  float: right;
+}
+
+/*
+ * The following styles are auto-applied to elements with
+ * transition="modal" when their visibility is toggled
+ * by Vue.js.
+ *
+ * You can easily play with the modal transition by editing
+ * these styles.
+ */
+
+.modal-enter {
+  opacity: 0;
+}
+
+.modal-leave-active {
+  opacity: 0;
+}
+
+.modal-enter .modal-container,
+.modal-leave-active .modal-container {
+  -webkit-transform: scale(1.1);
+  transform: scale(1.1);
+}
+
+</style>

--- a/front/src/components/home-components/HomeFooter.vue
+++ b/front/src/components/home-components/HomeFooter.vue
@@ -1,0 +1,32 @@
+<template>
+  <div class="clearAllContainer">
+    <span class='clearAllBtn' v-on:click="clearWord">Clear All</span>
+  </div>
+</template>
+
+<script>
+export default {
+  methods: {
+    clearWord: function() {
+	  this.$emit('clearWord');
+    }
+  }
+}
+</script>
+
+<style scoped>
+.clearAllContainer {
+  width: 8.5rem;
+  height: 50px;
+  line-height: 50px;
+  background-color: white;
+  border-radius: 5px;
+  margin: 0 auto;
+}
+
+.clearAllBtn {
+  color: #6138D4;
+  font-style: bold;
+  display: block;
+}
+</style>

--- a/front/src/components/home-components/HomeFooter.vue
+++ b/front/src/components/home-components/HomeFooter.vue
@@ -26,7 +26,7 @@ export default {
 
 .clearAllBtn {
   color: #6138D4;
-  font-style: bold;
+  font-weight: bold;
   display: block;
 }
 </style>

--- a/front/src/components/home-components/Input.vue
+++ b/front/src/components/home-components/Input.vue
@@ -17,9 +17,7 @@ export default {
 	methods: {
 		addWord: function() {
 			if (this.newWordItem !== "") {
-				var obj = {copied: false, item:this.newWordItem};
-				// 저장하는 로직
-				localStorage.setItem(this.newWordItem, JSON.stringify(obj));
+				this.$emit('addWord', this.newWordItem)
 				// 서버로 보내서 검색한 결과를 List에 출력
 				this.clearInput();
 			}

--- a/front/src/components/home-components/Input.vue
+++ b/front/src/components/home-components/Input.vue
@@ -4,14 +4,29 @@
 		<span class="addContainer" v-on:click="addWord">
 			<i class="fa-solid fa-play addBtn"/>
 		</span>
+
+		<modal v-if="showModal" @close="showModal = false">
+			<!--
+			이미 정의된 컴포넌트의 UI요소들은 바꾸기 힘들지만
+			slot을 통해서 특정 부분들을 재정의할 수 있어요.
+			-->
+			<h3 slot="header">경고
+				<i class="closeModalBtn fa-solid fa-xmark" @click="showModal = false"></i>
+			</h3>
+			<div slot="body">생성할 변수의 단어를 입력해주세요.</div>
+		</modal>
 	</div>
 </template>
 
 <script>
+import Modal from '../common/Modal.vue'
+
+
 export default {
 	data: function() {
 		return {
-			newWordItem : ""
+			newWordItem : "",
+			showModal : false
 		}
 	},
 	methods: {
@@ -21,10 +36,16 @@ export default {
 				// 서버로 보내서 검색한 결과를 List에 출력
 				this.clearInput();
 			}
+			else {
+				this.showModal = !this.showModal
+			}
 		},
 		clearInput: function() {
 			this.newWordItem = "";
 		}
+	},
+	components: {
+		'Modal': Modal
 	}
 }
 </script>
@@ -59,6 +80,11 @@ input:focus {
 .addBtn {
 	color: white;
 	vertical-align: middle;
+}
+
+.closeModalBtn {
+	color: #6138D4;
+	padding-left: 1%;
 }
 
 </style>

--- a/front/src/components/home-components/List.vue
+++ b/front/src/components/home-components/List.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-	  <ul>
+    <transition-group name="list" tag="ul">
       <li v-for="(word, idx) in propsdata" v-bind:key="word.item" class="shadow">
         <span class="copyBtn" v-bind:class="{copyBtnCompleted: word.copied}" v-on:click="copyComplete(word, idx)">
           <i class="fa-solid fa-copy"></i>
@@ -10,7 +10,7 @@
           <i class="fa-solid fa-trash-can"></i>
         </span>
       </li>
-    </ul>
+    </transition-group>
   </div>
 </template>
 
@@ -69,5 +69,16 @@ li {
 .removeBtn {
   margin-left: auto;
   color: #6138D4;
+}
+
+/* 리스트 아이템 트렌지션 효과 */
+
+.list-enter-active, .list-leave-active {
+  transition: all 0.5s;
+}
+
+.list-enter, .list-leave-to {
+  opacity: 0;
+  transform: translateY(20px);
 }
 </style>

--- a/front/src/components/home-components/List.vue
+++ b/front/src/components/home-components/List.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
 	  <ul>
-      <li v-for="(word, idx) in words" v-bind:key="word.item" class="shadow">
+      <li v-for="(word, idx) in propsdata" v-bind:key="word.item" class="shadow">
         <span class="copyBtn" v-bind:class="{copyBtnCompleted: word.copied}" v-on:click="copyComplete(word, idx)">
           <i class="fa-solid fa-copy"></i>
         </span>
@@ -16,29 +16,13 @@
 
 <script>
 export default {
-  data : function() {
-    return {
-      words : []
-    }
-  },
-  // 인스턴스 생성되자마자 실행되는 로직 created
-  created: function() {
-    if (localStorage.length > 0) {
-      for (var i=0; i<localStorage.length; i+= 1) {
-        this.words.push(JSON.parse(localStorage.getItem(localStorage.key(i))));
-        // this.words.push(localStorage.key(i));
-      }
-    }
-  },
+  props: ['propsdata'],
   methods: {
     removeWord: function(word, idx) {
-      localStorage.removeItem(word);
-      this.words.splice(idx, 1);
+      this.$emit('removeWord', word, idx)
     },
     copyComplete: function(word, idx) {
-      word.copied = !word.copied;
-      localStorage.removeItem(word.item);
-      localStorage.setItem(word.item, JSON.stringify(word));
+      this.$emit('copyComplete', word, idx)
     }
   }
 }

--- a/front/src/views/HomeView.vue
+++ b/front/src/views/HomeView.vue
@@ -2,9 +2,11 @@
   <div class="home">
     <img alt="Vue logo" src="../assets/logo.png" style="width:12vh">
     <HomeHeader></HomeHeader>
-    <Input></Input>
-    <List></List>
-    <Footer></Footer>
+    <Input v-on:addWord="addOneWord"></Input>
+    <List v-bind:propsdata="words" 
+      v-on:removeWord="removeOneWord" 
+      v-on:copyComplete="copyOneComplete"></List>
+    <Footer v-on:clearWord="clearAllWord"></Footer>
   </div>
 </template>
 
@@ -12,13 +14,58 @@
 import HomeHeader from '../components/home-components/HomeHeader.vue'
 import Input from '../components/home-components/Input.vue'
 import List from '../components/home-components/List.vue'
+import Footer from '../components/home-components/HomeFooter.vue'
 
 
 export default {
+  data: function() {
+    return {
+      words: []
+    }
+  },
+  methods: {
+    // 각각의 데이터들이 모두 동일 속성
+    // 상위 컴포넌트로 올려서 (한개의 컴포넌트로 모아서) 데이터 조작
+
+    // 단어 추가
+    addOneWord: function(wordItem) {
+      	var obj = {copied: false, item: wordItem};
+				// 저장하는 로직
+				localStorage.setItem(wordItem, JSON.stringify(obj));
+        this.words.push(obj);
+    },
+    // 단어 삭제
+    removeOneWord: function(word, idx) {
+      localStorage.removeItem(word.item);
+      this.words.splice(idx, 1);
+    },
+    // 단어 복사 (미구현)
+    copyOneComplete: function(word, idx) {
+      // word.copied = !word.copied;
+      // 직접 접근해서 좋은게 없어요
+      this.words[idx].copied = !this.words[idx].copied;
+      localStorage.removeItem(word.item);
+      localStorage.setItem(word.item, JSON.stringify(word));
+    },
+    // 단어 모두 삭제
+    clearAllWord: function() {
+      localStorage.clear();
+      this.words = [];
+    }
+  },
+  created: function() {
+    if (localStorage.length > 0) {
+      for (var i=0; i<localStorage.length; i+= 1) {
+        this.words.push(JSON.parse(localStorage.getItem(localStorage.key(i))));
+        // this.words.push(localStorage.key(i));
+      }
+    }
+  },
   components: {
     'HomeHeader' : HomeHeader,
     'Input' : Input,
     'List' : List,
+    'Footer' : Footer
   }
 }
 </script>


### PR DESCRIPTION
## Feat
1. 기존 Footer의 기능을 HomeFooter로 나누어 생성
2. HomeFooter : 검색 결과 전체 삭제 버튼 구현
3. Modal : 검색 input이 비었으면 경고창 출력
4. List : Transition 추가
## Refactor
1. HomeFooter, Input, List에서 각각 다루고 있던 word데이터 조작 함수
HomeView 컴포넌트에 취합
-> 같은 속성의 데이터